### PR TITLE
feat(buckets): add website field to enable GCS static website hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Module Input Variables
 - `default_custom_error_response_policy` - Default custom error response policy
 - `services` - map cloud run service metadata
 - `buckets` - map of gcs bucket metadata
+  - `name` - GCS bucket name
+  - `location` - bucket location
+  - `service_name` - backend bucket service name
+  - `website` - (optional, default `false`) enable GCS static website hosting; sets `main_page_suffix = index.html` and `not_found_page = index.html` so the load balancer serves `index.html` instead of returning an XML bucket listing
+  - `hosts` - list of hostnames to route to this bucket
+  - `path_rules` - map of path rules for URL routing
+  - `backend` - backend configuration (CDN, IAP, logging, CORS, custom response headers)
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,7 @@ module "buckets" {
   name                                 = each.value["name"]
   location                             = each.value["location"]
   service_name                         = each.value["service_name"]
+  website                              = each.value["website"]
   enable_cdn                           = each.value.backend["enable_cdn"]
   cdn_policy                           = each.value.backend["cdn_policy"]
   default_custom_error_response_policy = each.value.backend["default_custom_error_response_policy"]

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,7 @@ variable "buckets" {
     name         = string
     location     = string
     service_name = string
+    website      = optional(bool, false)
     hosts        = list(string)
     path_rules = map(object({
       paths = list(string)


### PR DESCRIPTION
## Summary
- Adds optional `website` field to the `buckets` variable (defaults to `false`, no breaking change)
- Passes `website` through to the `terraform-module-backend-bucket` submodule call in `main.tf`
- When `website = true`, the GCS bucket is configured with `main_page_suffix = index.html` and `not_found_page = index.html`, allowing the load balancer to serve the SPA correctly instead of returning an XML bucket listing

## Test plan
- [ ] Set `website = true` on a bucket in `terraform.tfvars` and run `terraform plan` to verify the backend-bucket module receives the argument
- [ ] Apply and confirm `https://greenroom.brandlive-sandbox.com/` serves the app instead of XML
- [ ] Confirm buckets without `website` set continue to behave as before (defaults to `false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)